### PR TITLE
#EA-1339 excluded apache xalan as it generates runtime conflicts with

### DIFF
--- a/zoho-import/pom.xml
+++ b/zoho-import/pom.xml
@@ -17,6 +17,12 @@
 			<groupId>eu.europeana.metis</groupId>
 			<artifactId>metis-enrichment-service</artifactId>
 			<version>1.0.0</version>
+			<exclusions>
+				<exclusion>
+					<groupId>xalan</groupId>
+					<artifactId>xalan</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
Saxon