### PR TITLE
MET-4106 Update log4j version 2.17.1 that fix CVE-2021-44832

### DIFF
--- a/deprecated/metis-enrichment-migration/pom.xml
+++ b/deprecated/metis-enrichment-migration/pom.xml
@@ -49,8 +49,8 @@
     <version.metis>1.10.0-SNAPSHOT</version.metis>
     <version.corelib>2.10.2-SNAPSHOT</version.corelib>
     <!-- These two versions are interdependent. -->
-    <version.slf4j>1.7.25</version.slf4j>
-    <version.log4j>2.17.0</version.log4j>
+    <version.slf4j>1.7.30</version.slf4j>
+    <version.log4j>2.17.1</version.log4j>
   </properties>
 
   <dependencies>

--- a/deprecated/metis-execution-speed/pom.xml
+++ b/deprecated/metis-execution-speed/pom.xml
@@ -49,7 +49,7 @@
     <version.metis>5</version.metis>
     <!-- These two versions are interdependent. -->
     <version.slf4j>1.7.30</version.slf4j>
-    <version.log4j>2.17.0</version.log4j>
+    <version.log4j>2.17.1</version.log4j>
   </properties>
 
   <dependencies>

--- a/deprecated/metis-migration-scripts/datasets-execution-script/pom.xml
+++ b/deprecated/metis-migration-scripts/datasets-execution-script/pom.xml
@@ -44,8 +44,8 @@
     <version.maven.compiler.plugin>3.6.1</version.maven.compiler.plugin>
     <version.metis>1.0-SNAPSHOT</version.metis>
     <!-- These two versions are interdependent. -->
-    <version.slf4j>1.7.25</version.slf4j>
-    <version.log4j>2.17.0</version.log4j>
+    <version.slf4j>1.7.30</version.slf4j>
+    <version.log4j>2.17.1</version.log4j>
   </properties>
 
   <dependencies>

--- a/deprecated/metis-migration-scripts/export-dataset-info/pom.xml
+++ b/deprecated/metis-migration-scripts/export-dataset-info/pom.xml
@@ -42,8 +42,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <version.metis>1.0-SNAPSHOT</version.metis>
     <!-- These two versions are interdependent. -->
-    <version.slf4j>1.7.25</version.slf4j>
-    <version.log4j>2.17.0</version.log4j>
+    <version.slf4j>1.7.30</version.slf4j>
+    <version.log4j>2.17.1</version.log4j>
   </properties>
 
   <dependencies>

--- a/deprecated/metis-migration-scripts/metis-redirects-migration/pom.xml
+++ b/deprecated/metis-migration-scripts/metis-redirects-migration/pom.xml
@@ -53,8 +53,8 @@
     <version.metis>1.8.0-SNAPSHOT</version.metis>
     <version.corelib>2.9.3-SNAPSHOT</version.corelib>
     <!-- These two versions are interdependent. -->
-    <version.slf4j>1.7.25</version.slf4j>
-    <version.log4j>2.17.0</version.log4j>
+    <version.slf4j>1.7.30</version.slf4j>
+    <version.log4j>2.17.1</version.log4j>
   </properties>
 
   <dependencies>

--- a/metis-database-creator/pom.xml
+++ b/metis-database-creator/pom.xml
@@ -21,8 +21,8 @@
     <version.metis>4-SNAPSHOT</version.metis>
     <version.corelib>2.12.2-SNAPSHOT</version.corelib>
     <!-- These two versions are interdependent. -->
-    <version.slf4j>1.7.25</version.slf4j>
-    <version.log4j>2.17.0</version.log4j>
+    <version.slf4j>1.7.30</version.slf4j>
+    <version.log4j>2.17.1</version.log4j>
   </properties>
 
   <build>

--- a/metis-dataset-sizes-updater/pom.xml
+++ b/metis-dataset-sizes-updater/pom.xml
@@ -18,8 +18,8 @@
     <version.maven.compiler.plugin>3.8.1</version.maven.compiler.plugin>
     <version.metis>6-SNAPSHOT</version.metis>
 <!--    &lt;!&ndash; These two versions are interdependent. &ndash;&gt;-->
-    <version.slf4j>1.7.25</version.slf4j>
-    <version.log4j>2.17.0</version.log4j>
+    <version.slf4j>1.7.30</version.slf4j>
+    <version.log4j>2.17.1</version.log4j>
   </properties>
 
   <build>

--- a/metis-enrichment-populator/pom.xml
+++ b/metis-enrichment-populator/pom.xml
@@ -18,11 +18,12 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <version.maven.compiler.plugin>3.8.1</version.maven.compiler.plugin>
-    <version.metis>3-SNAPSHOT</version.metis>
-    <version.corelib>2.11.0</version.corelib>
+    <version.metis>6-SNAPSHOT</version.metis>
+    <version.corelib>2.14.1-SNAPSHOT</version.corelib>
     <!-- These two versions are interdependent. -->
-    <version.slf4j>1.7.25</version.slf4j>
-    <version.log4j>2.17.0</version.log4j>
+    <version.slf4j>1.7.30</version.slf4j>
+    <version.log4j>2.17.1</version.log4j>
+    <version.apache.commons>2.6</version.apache.commons>
   </properties>
 
   <build>
@@ -109,6 +110,11 @@
       <artifactId>log4j-core</artifactId>
       <version>${version.log4j}</version>
     </dependency>
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>${version.apache.commons}</version>
+    </dependency>
   </dependencies>
 
   <repositories>
@@ -116,7 +122,7 @@
     <repository>
       <id>libs-release</id>
       <name>libs-release</name>
-      <url>http://artifactory.eanadev.org/artifactory/libs-release</url>
+      <url>https://artifactory.eanadev.org/artifactory/libs-release</url>
       <releases>
         <enabled>true</enabled>
       </releases>
@@ -127,7 +133,7 @@
     <repository>
       <id>libs-snapshot</id>
       <name>libs-snapshot</name>
-      <url>http://artifactory.eanadev.org/artifactory/libs-snapshot</url>
+      <url>https://artifactory.eanadev.org/artifactory/libs-snapshot</url>
       <releases>
         <enabled>false</enabled>
       </releases>

--- a/metis-enrichment-populator/src/main/java/eu/europeana/metis/enrichment/utilities/ConfigurationPropertiesHolder.java
+++ b/metis-enrichment-populator/src/main/java/eu/europeana/metis/enrichment/utilities/ConfigurationPropertiesHolder.java
@@ -17,6 +17,8 @@ import org.springframework.context.annotation.PropertySource;
 @PropertySource("classpath:application.properties")
 public class ConfigurationPropertiesHolder {
 
+  private static final String ENRICHMENT_APP_NAME = "Enrichment-util-app";
+
   @Value("${truststore.path}")
   public  String truststorePath;
   @Value("${truststore.password}")
@@ -50,7 +52,7 @@ public class ConfigurationPropertiesHolder {
     final MongoProperties<IllegalArgumentException> mongoProperties = new MongoProperties<>(
         IllegalArgumentException::new);
     mongoProperties.setAllProperties(mongoHosts, mongoPorts, mongoAuthenticationDb, mongoUsername,
-        mongoPassword, mongoEnableSSL, null);
+        mongoPassword, mongoEnableSSL, null, ENRICHMENT_APP_NAME);
     return mongoProperties;
   }
 

--- a/metis-enrichment-populator/src/main/java/eu/europeana/metis/enrichment/utilities/EnrichmentTermUtils.java
+++ b/metis-enrichment-populator/src/main/java/eu/europeana/metis/enrichment/utilities/EnrichmentTermUtils.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
 import org.apache.commons.lang.StringUtils;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
@@ -78,7 +79,7 @@ public class EnrichmentTermUtils {
     //isPartOf
     final List<Element> isPartOfElements = XmlUtil
         .getAsElementList(timeSpan.getElementsByTagNameNS(Namespace.DCTERMS.getUri(), "isPartOf"));
-    timespanEnrichmentEntity.setIsPartOf(getMapFromElementsWithResource(isPartOfElements));
+    timespanEnrichmentEntity.setIsPartOf(getMapFromElementsWithResource(isPartOfElements).get("def").get(0));
 
     //isNextInSequence
     final List<Element> isNextInSequenceList = XmlUtil.getAsElementList(
@@ -96,7 +97,7 @@ public class EnrichmentTermUtils {
 
     final EnrichmentTerm enrichmentTerm = new EnrichmentTerm();
     enrichmentTerm.setEntityType(EntityType.TIMESPAN);
-    enrichmentTerm.setParent(timespanEnrichmentEntity.getIsPartOf().get("def").get(0));
+    enrichmentTerm.setParent(timespanEnrichmentEntity.getIsPartOf());
     enrichmentTerm.setEnrichmentEntity(timespanEnrichmentEntity);
     enrichmentTerm.setLabelInfos(createLabelInfoList(timespanEnrichmentEntity));
 

--- a/metis-inc-harvest-data/pom.xml
+++ b/metis-inc-harvest-data/pom.xml
@@ -29,8 +29,8 @@
     <version.metis>5-SNAPSHOT</version.metis>
     <version.javax.xml.bind>2.3.1</version.javax.xml.bind>
     <!-- These two versions are interdependent. -->
-    <version.slf4j>1.7.25</version.slf4j>
-    <version.log4j>2.17.0</version.log4j>
+    <version.slf4j>1.7.30</version.slf4j>
+    <version.log4j>2.17.1</version.log4j>
   </properties>
 
   <dependencies>

--- a/metis-mongo-operator/pom.xml
+++ b/metis-mongo-operator/pom.xml
@@ -22,8 +22,8 @@
     <version.metis>1.10.0-SNAPSHOT</version.metis>
     <version.corelib>2.11.0-SNAPSHOT</version.corelib>
     <!-- These two versions are interdependent. -->
-    <version.slf4j>1.7.25</version.slf4j>
-    <version.log4j>2.17.0</version.log4j>
+    <version.slf4j>1.7.30</version.slf4j>
+    <version.log4j>2.17.1</version.log4j>
     <start-class>eu.europeana.metis.mongo.analyzer.MongoOperatorMain</start-class>
   </properties>
 

--- a/metis-oaipmh-harvest-tool/pom.xml
+++ b/metis-oaipmh-harvest-tool/pom.xml
@@ -29,8 +29,8 @@
     <version.metis>1.10.0-SNAPSHOT</version.metis>
     <version.javax.xml.bind>2.3.1</version.javax.xml.bind>
     <!-- These two versions are interdependent. -->
-    <version.slf4j>1.7.25</version.slf4j>
-    <version.log4j>2.17.0</version.log4j>
+    <version.slf4j>1.7.30</version.slf4j>
+    <version.log4j>2.17.1</version.log4j>
   </properties>
 
   <dependencies>

--- a/metis-remove-data/pom.xml
+++ b/metis-remove-data/pom.xml
@@ -44,8 +44,8 @@
     <version.metis>5-SNAPSHOT</version.metis>
     <version.javax.xml.bind>2.3.1</version.javax.xml.bind>
     <!-- These two versions are interdependent. -->
-    <version.slf4j>1.7.25</version.slf4j>
-    <version.log4j>2.17.0</version.log4j>
+    <version.slf4j>1.7.30</version.slf4j>
+    <version.log4j>2.17.1</version.log4j>
   </properties>
 
   <dependencies>

--- a/metis-reprocessing/pom.xml
+++ b/metis-reprocessing/pom.xml
@@ -50,7 +50,7 @@
     <version.corelib>2.14.1-SNAPSHOT</version.corelib>
     <!-- These two versions are interdependent. -->
     <version.slf4j>1.7.30</version.slf4j>
-    <version.log4j>2.17.0</version.log4j>
+    <version.log4j>2.17.1</version.log4j>
   </properties>
 
   <dependencies>

--- a/metis-technical-metadata-generation/pom.xml
+++ b/metis-technical-metadata-generation/pom.xml
@@ -15,10 +15,10 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${version.maven.compiler.plugin}</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-          <testSource>1.8</testSource>
-          <testTarget>1.8</testTarget>
+          <source>11</source>
+          <target>11</target>
+          <testSource>11</testSource>
+          <testTarget>11</testTarget>
         </configuration>
       </plugin>
       <plugin>
@@ -48,12 +48,13 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.maven.compiler.plugin>3.6.1</version.maven.compiler.plugin>
-    <version.metis>1.4.0-SNAPSHOT</version.metis>
+    <version.maven.compiler.plugin>3.8.1</version.maven.compiler.plugin>
+    <version.metis>6-SNAPSHOT</version.metis>
     <!-- These two versions are interdependent. -->
-    <version.slf4j>1.7.25</version.slf4j>
-    <version.log4j>2.17.0</version.log4j>
+    <version.slf4j>1.7.30</version.slf4j>
+    <version.log4j>2.17.1</version.log4j>
     <version.aws-java-sdk-s3>1.11.64</version.aws-java-sdk-s3>
+    <version.morphia>1.3.2</version.morphia>
   </properties>
 
   <dependencies>
@@ -104,5 +105,12 @@
       <version>${version.aws-java-sdk-s3}</version>
       <scope>compile</scope>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/org.mongodb.morphia/morphia -->
+    <dependency>
+      <groupId>org.mongodb.morphia</groupId>
+      <artifactId>morphia</artifactId>
+      <version>${version.morphia}</version>
+    </dependency>
+
   </dependencies>
 </project>

--- a/metis-technical-metadata-generation/src/main/java/eu/europeana/metis/technical/metadata/generation/ProgressCheckerMain.java
+++ b/metis-technical-metadata-generation/src/main/java/eu/europeana/metis/technical/metadata/generation/ProgressCheckerMain.java
@@ -6,6 +6,7 @@ import eu.europeana.metis.technical.metadata.generation.utilities.MediaExtractor
 import eu.europeana.metis.technical.metadata.generation.utilities.MongoDao;
 import eu.europeana.metis.technical.metadata.generation.utilities.MongoInitializer;
 import eu.europeana.metis.technical.metadata.generation.utilities.PropertiesHolder;
+import eu.europeana.metis.utils.CustomTruststoreAppender.TrustStoreConfigurationException;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -14,7 +15,6 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
-import org.apache.logging.log4j.core.net.ssl.TrustStoreConfigurationException;
 import org.mongodb.morphia.Datastore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,7 +25,7 @@ public class ProgressCheckerMain {
 
   private static final String CONFIGURATION_FILE = "application.properties";
 
-  public static void main(String[] args) throws TrustStoreConfigurationException, IOException {
+  public static void main(String[] args) throws IOException, TrustStoreConfigurationException {
 
     // Initialize.
     LOGGER.info("Starting script - initializing connections.");

--- a/metis-technical-metadata-generation/src/main/java/eu/europeana/metis/technical/metadata/generation/ResetFileStatusMain.java
+++ b/metis-technical-metadata-generation/src/main/java/eu/europeana/metis/technical/metadata/generation/ResetFileStatusMain.java
@@ -5,9 +5,9 @@ import eu.europeana.metis.technical.metadata.generation.utilities.ExecutorManage
 import eu.europeana.metis.technical.metadata.generation.utilities.MongoDao;
 import eu.europeana.metis.technical.metadata.generation.utilities.MongoInitializer;
 import eu.europeana.metis.technical.metadata.generation.utilities.PropertiesHolder;
+import eu.europeana.metis.utils.CustomTruststoreAppender.TrustStoreConfigurationException;
 import java.io.File;
 import java.io.IOException;
-import org.apache.logging.log4j.core.net.ssl.TrustStoreConfigurationException;
 import org.mongodb.morphia.Datastore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,7 +19,7 @@ public class ResetFileStatusMain {
 
   private static final String CONFIGURATION_FILE = "application.properties";
 
-  public static void main(String[] args) throws TrustStoreConfigurationException, IOException {
+  public static void main(String[] args) throws IOException, TrustStoreConfigurationException {
 
     // Initialize.
     LOGGER.info("Starting script - initializing connections.");

--- a/metis-technical-metadata-generation/src/main/java/eu/europeana/metis/technical/metadata/generation/TechnicalMetadataGenerationMain.java
+++ b/metis-technical-metadata-generation/src/main/java/eu/europeana/metis/technical/metadata/generation/TechnicalMetadataGenerationMain.java
@@ -10,8 +10,8 @@ import eu.europeana.metis.technical.metadata.generation.utilities.ExecutorManage
 import eu.europeana.metis.technical.metadata.generation.utilities.MongoInitializer;
 import eu.europeana.metis.technical.metadata.generation.utilities.PropertiesHolder;
 import eu.europeana.metis.utils.CustomTruststoreAppender;
+import eu.europeana.metis.utils.CustomTruststoreAppender.TrustStoreConfigurationException;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.core.net.ssl.TrustStoreConfigurationException;
 import org.mongodb.morphia.Datastore;
 import org.mongodb.morphia.Morphia;
 import org.slf4j.Logger;
@@ -44,8 +44,7 @@ public class TechnicalMetadataGenerationMain {
 
   }
 
-  static MongoInitializer prepareConfiguration(PropertiesHolder propertiesHolder)
-      throws TrustStoreConfigurationException {
+  static MongoInitializer prepareConfiguration(PropertiesHolder propertiesHolder) throws TrustStoreConfigurationException {
     if (StringUtils.isNotEmpty(propertiesHolder.truststorePath) && StringUtils
         .isNotEmpty(propertiesHolder.truststorePassword)) {
       LOGGER.info(EXECUTION_LOGS_MARKER,

--- a/metis-technical-metadata-generation/src/main/java/eu/europeana/metis/technical/metadata/generation/ThumbnailUploadProgressCheckerMain.java
+++ b/metis-technical-metadata-generation/src/main/java/eu/europeana/metis/technical/metadata/generation/ThumbnailUploadProgressCheckerMain.java
@@ -5,9 +5,9 @@ import eu.europeana.metis.technical.metadata.generation.model.ThumbnailFileStatu
 import eu.europeana.metis.technical.metadata.generation.utilities.MongoDao;
 import eu.europeana.metis.technical.metadata.generation.utilities.MongoInitializer;
 import eu.europeana.metis.technical.metadata.generation.utilities.PropertiesHolder;
+import eu.europeana.metis.utils.CustomTruststoreAppender.TrustStoreConfigurationException;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.apache.logging.log4j.core.net.ssl.TrustStoreConfigurationException;
 import org.mongodb.morphia.Datastore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/metis-technical-metadata-generation/src/main/java/eu/europeana/metis/technical/metadata/generation/model/DatasetFileStatus.java
+++ b/metis-technical-metadata-generation/src/main/java/eu/europeana/metis/technical/metadata/generation/model/DatasetFileStatus.java
@@ -1,6 +1,6 @@
 package eu.europeana.metis.technical.metadata.generation.model;
 
-import eu.europeana.metis.core.workflow.HasMongoObjectId;
+import eu.europeana.metis.mongo.model.HasMongoObjectId;
 
 /**
  * @author Simon Tzanakis (Simon.Tzanakis@europeana.eu)

--- a/metis-technical-metadata-generation/src/main/java/eu/europeana/metis/technical/metadata/generation/model/FileStatus.java
+++ b/metis-technical-metadata-generation/src/main/java/eu/europeana/metis/technical/metadata/generation/model/FileStatus.java
@@ -1,7 +1,7 @@
 package eu.europeana.metis.technical.metadata.generation.model;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import eu.europeana.metis.json.ObjectIdSerializer;
+import eu.europeana.metis.mongo.utils.ObjectIdSerializer;
 import org.bson.types.ObjectId;
 import org.mongodb.morphia.annotations.Id;
 import org.mongodb.morphia.annotations.IndexOptions;

--- a/metis-technical-metadata-generation/src/main/java/eu/europeana/metis/technical/metadata/generation/model/TechnicalMetadataWrapper.java
+++ b/metis-technical-metadata-generation/src/main/java/eu/europeana/metis/technical/metadata/generation/model/TechnicalMetadataWrapper.java
@@ -1,8 +1,8 @@
 package eu.europeana.metis.technical.metadata.generation.model;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import eu.europeana.metis.core.workflow.HasMongoObjectId;
-import eu.europeana.metis.json.ObjectIdSerializer;
+import eu.europeana.metis.mongo.model.HasMongoObjectId;
+import eu.europeana.metis.mongo.utils.ObjectIdSerializer;
 import eu.europeana.metis.mediaprocessing.model.ResourceMetadata;
 import java.util.List;
 import org.bson.types.ObjectId;

--- a/metis-technical-metadata-generation/src/main/java/eu/europeana/metis/technical/metadata/generation/model/ThumbnailFileStatus.java
+++ b/metis-technical-metadata-generation/src/main/java/eu/europeana/metis/technical/metadata/generation/model/ThumbnailFileStatus.java
@@ -1,7 +1,7 @@
 package eu.europeana.metis.technical.metadata.generation.model;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import eu.europeana.metis.json.ObjectIdSerializer;
+import eu.europeana.metis.mongo.utils.ObjectIdSerializer;
 import org.bson.types.ObjectId;
 import org.mongodb.morphia.annotations.Id;
 import org.mongodb.morphia.annotations.IndexOptions;

--- a/zoho-import/pom.xml
+++ b/zoho-import/pom.xml
@@ -6,14 +6,14 @@
 	<artifactId>zoho-import</artifactId>
 	<version>0.2-SNAPSHOT</version>
 	<properties>
-		<version.log4j>2.17.0</version.log4j>
+		<version.log4j>2.17.1</version.log4j>
 	</properties>
 
 	<repositories>
 		<repository>
 			<id>libs-release-local</id>
 			<name>europeana-releases</name>
-			<url>http://artifactory.eanadev.org/artifactory/libs-release-local/</url>
+			<url>https://artifactory.eanadev.org/artifactory/libs-release-local/</url>
 		</repository>
 	</repositories>
 
@@ -21,7 +21,7 @@
 		<dependency>
 			<groupId>eu.europeana.metis</groupId>
 			<artifactId>metis-enrichment-service</artifactId>
-			<version>5-SNAPSHOT</version>
+			<version>6-SNAPSHOT</version>
 			<exclusions>
 				<exclusion>
 					<groupId>xalan</groupId>
@@ -63,10 +63,10 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.7.0</version>
+				<version>3.8.1</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>11</source>
+					<target>11</target>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
Update log4j version from 2.17.0 to 2.17.1 to fix CVE-2021-44832